### PR TITLE
Upgrade to react 15.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel": "^5.1.13",
     "babel-core": "^5.1.13",
     "babel-eslint": "^3.1.7",
+    "escope": "^3.3.0",
     "eslint": "^0.21.2",
     "eslint-plugin-react": "^2.5.2",
     "tomchentw-npm-dev": "^3.0.0"
@@ -62,11 +63,11 @@
   "dependencies": {
     "google-maps-infobox": "^1.1.13",
     "object-path": "^0.9.2",
-    "react": "^0.14.0",
+    "react": "^15.3.2",
     "warning": "3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2"
   }
 }


### PR DESCRIPTION
upping version of react for shipper web. Can still be used with .14 by pointing to the previous commit hash. Wasn't using an 14 only feature so the upgrade to 15 was just managing dependencies. 